### PR TITLE
CMakeList.txt for linux ccsds serial driver modified

### DIFF
--- a/src/linux_serial_ccsds/CMakeLists.txt
+++ b/src/linux_serial_ccsds/CMakeLists.txt
@@ -4,9 +4,9 @@ target_sources(LinuxSerialCcsds
   PUBLIC    linux_serial_ccsds.h)
 
 target_include_directories(LinuxSerialCcsds
-  PRIVATE   ..
-            ../../TASTE-Linux-Runtime/src
-  PUBLIC    ../RuntimeMocks)
+  PRIVATE   ${CMAKE_CURRENT_SOURCE_DIR}/../
+            ${CMAKE_CURRENT_SOURCE_DIR}/../../TASTE-Linux-Runtime/src
+  PUBLIC    ${CMAKE_CURRENT_SOURCE_DIR}/../RuntimeMocks)
 
 target_link_libraries(LinuxSerialCcsds
   PRIVATE   common_build_options

--- a/src/linux_serial_ccsds/CMakeLists.txt
+++ b/src/linux_serial_ccsds/CMakeLists.txt
@@ -4,9 +4,9 @@ target_sources(LinuxSerialCcsds
   PUBLIC    linux_serial_ccsds.h)
 
 target_include_directories(LinuxSerialCcsds
-  PRIVATE   ${CMAKE_SOURCE_DIR}/src
-            ${CMAKE_SOURCE_DIR}/TASTE-Linux-Runtime/src
-  PUBLIC    ${CMAKE_SOURCE_DIR}/src/RuntimeMocks)
+  PRIVATE   ..
+            ../../TASTE-Linux-Runtime/src
+  PUBLIC    ../RuntimeMocks)
 
 target_link_libraries(LinuxSerialCcsds
   PRIVATE   common_build_options


### PR DESCRIPTION
CMakeList.txt for linux ccsds serial driver needed to be modified in order to make it possible to include TASTE-Linux-Drivers as a submodule